### PR TITLE
Bump plugin version to 1.1.0

### DIFF
--- a/plugins/ado-flow/.claude-plugin/plugin.json
+++ b/plugins/ado-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ado-flow",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Manage Azure DevOps work items, pull requests, and pipelines using natural language. Provides /adoflow:workitems, /adoflow:prs, and /adoflow:pipelines slash commands.",
   "author": {
     "name": "Niketan Rane",


### PR DESCRIPTION
## Summary
- Bump ado-flow plugin version from 1.0.0 to 1.1.0 in `plugin.json`
- Allows Claude Code to detect the update after the command path fix in #5

## Test plan
- [ ] After merging, run `/plugin install ado-flow@shanashma` and confirm it picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)