### PR TITLE
Bump ado-flow to v1.3.0

### DIFF
--- a/plugins/ado-flow/.claude-plugin/plugin.json
+++ b/plugins/ado-flow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ado-flow",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Manage Azure DevOps work items, pull requests, and pipelines using natural language. Provides /adoflow:workitems, /adoflow:prs, /adoflow:pipelines, and /adoflow:sprint-update slash commands.",
   "author": {
     "name": "Niketan Rane",


### PR DESCRIPTION
## Summary

Version bump to trigger auto-update for all users. Includes all sprint-update optimizations landed in main:

- **4-5 API calls** (down from 40+) via az rest, computed sprint paths, batch relations
- **Windows fixes** across all commands ($HOME paths, node instead of python, file-based output)
- **Server-side PR filtering** via searchCriteria.minTime + creatorId

## Test plan

- [ ] `plugin update ado-flow` pulls 1.3.0
- [ ] `/sprint-update` completes with ~4-5 API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)