### PR TITLE
Add standup, link-prs, and morning commands (ado-flow v1.4.0)

### DIFF
--- a/plugins/ado-flow/.claude-plugin/plugin.json
+++ b/plugins/ado-flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ado-flow",
-  "version": "1.3.0",
-  "description": "Manage Azure DevOps work items, pull requests, and pipelines using natural language. Provides /adoflow:workitems, /adoflow:prs, /adoflow:pipelines, and /adoflow:sprint-update slash commands.",
+  "version": "1.4.0",
+  "description": "Manage Azure DevOps work items, pull requests, and pipelines using natural language. Provides /adoflow:workitems, /adoflow:prs, /adoflow:pipelines, /adoflow:sprint-update, /adoflow:standup, /adoflow:link-prs, and /adoflow:morning slash commands.",
   "author": {
     "name": "Niketan Rane",
     "email": "niketan.iiita@gmail.com",
@@ -15,6 +15,9 @@
     "work-items",
     "pull-requests",
     "pipelines",
-    "devops"
+    "devops",
+    "standup",
+    "morning-briefing",
+    "pr-linking"
   ]
 }

--- a/plugins/ado-flow/commands/adoflow.md
+++ b/plugins/ado-flow/commands/adoflow.md
@@ -17,7 +17,10 @@ This is the unified entry point for all Azure DevOps operations. Analyze the use
 - **Work items:** create a bug, list my items, show #1234, update a task
 - **Pull requests:** create a PR, list my PRs, approve PR #42, show comments
 - **Pipelines:** list pipelines, run Build-CI, show build #567, cancel a build
-- **Sprint update:** show my sprint updates, sprint progress report"
+- **Sprint update:** show my sprint updates, sprint progress report
+- **Standup:** generate my standup, daily summary
+- **Link PRs:** link unlinked PRs, find orphan PRs
+- **Morning:** morning briefing, what should I work on"
 
 Do not proceed until you have a clear request from the user.
 
@@ -60,6 +63,34 @@ Route to the **Sprint Update** workflow if the request mentions any of these:
 - Cross-referencing **work items** with **merged PRs**
 - Asking for a **status update** or **progress summary** on sprint items
 
+### Standup
+
+Route to the **Standup** workflow if the request mentions any of these:
+- **Standup**, **daily standup**, **standup summary**, or **standup report**
+- **What did I do yesterday**, **daily summary**, or **daily update**
+- Generating a **standup** or **daily** for Teams/Slack
+
+### Link PRs
+
+Route to the **Link PRs** workflow if the request mentions any of these:
+- **Link PRs**, **link pull requests**, **unlinked PRs**, or **orphan PRs**
+- **Connect PRs to work items**, **link my PRs**, or **PR linking**
+- Finding **unlinked** or **orphaned** pull requests
+
+### Morning
+
+Route to the **Morning** workflow if the request mentions any of these:
+- **Morning**, **morning briefing**, **morning summary**, or **daily briefing**
+- **What should I work on**, **daily overview**, or **today's priorities**
+- **Review queue**, **what needs my attention**, or **overnight changes**
+
+### Standup vs Morning Overlap
+
+"Daily summary" could match either Standup or Morning. Use this rule:
+- If the request focuses on **what I did** or **generating a standup** -> Standup
+- If the request focuses on **what I should do next** or **what needs my attention** -> Morning
+- If truly ambiguous, default to **Morning** (it is a superset that includes yesterday's activity)
+
 ### Ambiguous Requests
 
 If the request could match multiple domains (e.g., "show #42" could be a work item or a PR), ask the user to clarify:
@@ -68,7 +99,7 @@ If the request could match multiple domains (e.g., "show #42" could be a work it
 
 If the request does not match any domain, say:
 
-> "I'm not sure what you're looking for. I can help with **work items**, **pull requests**, or **pipelines**. Could you tell me which one?"
+> "I'm not sure what you're looking for. I can help with **work items**, **pull requests**, **pipelines**, **sprint updates**, **standups**, **PR linking**, or **morning briefings**. Could you tell me which one?"
 
 ---
 
@@ -123,3 +154,33 @@ Once classified as a sprint update request, follow the full instructions in the 
 Use `{ORG}`, `{WORK_ITEM_PROJECT}`, and `{PR_PROJECT}` from the loaded config.
 
 Refer to the `adoflow:sprint-update` command for the full workflow: detect current sprint, fetch active work items, cross-reference with merged PRs, auto-classify items, bulk-confirm state changes, add progress comments, flag blockers, and link orphaned PRs.
+
+---
+
+## Standup Workflow
+
+Once classified as a standup request, follow the full instructions in the `adoflow:standup` command to handle the request.
+
+Use `{ORG}`, `{WORK_ITEM_PROJECT}`, and `{PR_PROJECT}` from the loaded config.
+
+Refer to the `adoflow:standup` command for the full workflow: fetch work items changed in last 24h, fetch PRs created/reviewed, generate a copy-paste-ready standup for Teams/Slack.
+
+---
+
+## Link PRs Workflow
+
+Once classified as a link-PRs request, follow the full instructions in the `adoflow:link-prs` command to handle the request.
+
+Use `{ORG}`, `{WORK_ITEM_PROJECT}`, and `{PR_PROJECT}` from the loaded config.
+
+Refer to the `adoflow:link-prs` command for the full workflow: fetch sprint work items with PR links, fetch sprint PRs, match unlinked PRs to work items via branch names/titles/fuzzy matching, confirm and apply links.
+
+---
+
+## Morning Workflow
+
+Once classified as a morning request, follow the full instructions in the `adoflow:morning` command to handle the request.
+
+Use `{ORG}`, `{WORK_ITEM_PROJECT}`, and `{PR_PROJECT}` from the loaded config.
+
+Refer to the `adoflow:morning` command for the full workflow: fetch review queue, your PR status, sprint progress, pipeline builds, and generate prioritized action items.

--- a/plugins/ado-flow/commands/link-prs.md
+++ b/plugins/ado-flow/commands/link-prs.md
@@ -1,0 +1,440 @@
+---
+name: adoflow:link-prs
+description: Find unlinked PRs in the current sprint and link them to matching work items
+argument-hint: "[link unlinked PRs | find orphan PRs | link my PRs to work items]"
+---
+
+# Azure DevOps Link PRs
+
+Finds PRs in the current sprint that are not linked to any work item, matches them using branch names / titles / descriptions, and links them with confirmation.
+
+**Read/write command.** This command creates PR-to-work-item links in Azure DevOps. Requires `vso.code_write` and `vso.work_write` scopes.
+
+## Arguments
+
+<user_request> $ARGUMENTS </user_request>
+
+**If empty, proceed with default workflow.**
+
+---
+
+## Hard Rules
+
+1. **All data-fetching uses `az rest`.** Do not use `az boards query`, `az boards work-item show`, `az repos pr list`, or `az boards iteration *` for fetching. Only use `az boards work-item update` for writes. Use `az repos pr work-item add` for linking.
+2. **Always write az output to a file.** Pattern: `az rest ... -o json 2>/dev/null > "$HOME/ado-flow-tmp-{name}.json"`. Windows `az` CLI emits encoding warnings that corrupt inline JSON.
+3. **For scripts longer than 3 lines, write to a .js file** and run with `node "$HOME/ado-flow-tmp-{name}.js"`. Do not use `node -e` for complex scripts — backslash escaping breaks on Windows. For 1-3 line scripts, `node -e` is fine.
+4. **Never use `python3` or `python`.** Never pipe into node via stdin. Always read from files.
+5. **Never use `/tmp/`.** It resolves to `C:\tmp\` in Node.js on Windows. Use `$HOME/ado-flow-tmp-*` for all temp files.
+6. **Never run data-collection in the background.** All data must be collected before presenting matches.
+7. **Do not use `$expand` and `fields` together** in the batch API. They conflict. Use `$expand=Relations` alone — it returns all fields automatically.
+8. **connectionData API requires `api-version=7.1-preview`** (not `7.1`).
+9. **Clean up temp files** at the end: `rm -f "$HOME"/ado-flow-tmp-*.json "$HOME"/ado-flow-tmp-*.js 2>/dev/null`
+10. **Never loop through PRs to fetch linked work items.** The batch API `$expand=Relations` provides all PR links in one call.
+
+---
+
+## Phase 0: Load Config (0 az calls)
+
+```bash
+cat "$HOME/.config/ado-flow/config.json" 2>/dev/null
+```
+
+If no config exists, follow the `ado-flow` skill for first-time setup.
+
+**Accept both key formats:** `organization` or `ORG`, `work_item_project` or `WORK_ITEM_PROJECT`, `pr_project` or `PR_PROJECT`.
+
+Map to: `{ORG}`, `{WI_PROJECT}`, `{PR_PROJECT}`.
+
+Also check for cached: `user_id` (GUID), `user_email`.
+
+### Project Routing Rule
+
+| API | Project |
+|-----|---------|
+| `_apis/wit/*` (WIQL, batch, work items) | `{WI_PROJECT}` |
+| `_apis/git/pullrequests` | `{PR_PROJECT}` |
+
+**Never swap.** `{WI_PROJECT}` and `{PR_PROJECT}` may be different.
+
+---
+
+## Phase 1: Resolve Identity + Compute Sprint (0-1 az calls)
+
+### 1a: User Identity (0-1 calls, cached)
+
+Check config for `user_id` and `user_email`. **If both present, skip.**
+
+If missing (1 call):
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/_apis/connectionData?api-version=7.1-preview" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-conn.json"
+```
+
+Extract `authenticatedUser.id` -> `{USER_ID}` (GUID). If email not in response, get via `az account show --query "user.name" -o tsv 2>/dev/null`.
+
+**Cache immediately** in config.
+
+### 1b: Compute Sprint from Today's Date (0 calls)
+
+The iteration path follows a fixed format: `{WI_PROJECT}\{year}\H{half}\Q{quarter}\{month_name}`.
+
+**Compute it from today's date — no API call needed:**
+
+```javascript
+const now = new Date();
+const year = now.getFullYear();
+const month = now.getMonth(); // 0-indexed
+const monthNames = ['January','February','March','April','May','June',
+                    'July','August','September','October','November','December'];
+const quarter = Math.floor(month / 3) + 1; // Q1-Q4
+const half = month < 6 ? 1 : 2; // H1 or H2
+
+const iterationPath = `{WI_PROJECT}\\${year}\\H${half}\\Q${quarter}\\${monthNames[month]}`;
+
+// Sprint dates = first and last day of the current month
+const sprintStart = `${year}-${String(month+1).padStart(2,'0')}-01`;
+const lastDay = new Date(year, month+1, 0).getDate();
+const sprintEnd = `${year}-${String(month+1).padStart(2,'0')}-${lastDay}`;
+```
+
+Store: `{CURRENT_ITERATION}`, `{SPRINT_START}`, `{SPRINT_END}`.
+
+---
+
+## Phase 2: Fetch Sprint Work Items with PR Links (2 az calls)
+
+### 2a: WIQL Query — Sprint Items (1 call)
+
+```bash
+node -e "
+const fs=require('fs'), os=require('os'), p=require('path');
+fs.writeFileSync(p.join(os.homedir(),'ado-flow-tmp-wiql-body.json'),
+  JSON.stringify({query: \"SELECT [System.Id] FROM workitems WHERE [System.AssignedTo] = @me AND [System.IterationPath] = '{CURRENT_ITERATION}' ORDER BY [System.WorkItemType] ASC\"}));
+"
+```
+
+Note: Include ALL states (not just active) — we want to link PRs to resolved items too.
+
+```bash
+az rest --method post \
+  --url "https://dev.azure.com/{ORG}/{WI_PROJECT}/_apis/wit/wiql?api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  --body "@$HOME/ado-flow-tmp-wiql-body.json" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-wiql.json"
+```
+
+If 0 results, output "No items in `{CURRENT_ITERATION}`. Nothing to link." and stop.
+
+### 2b: Batch Fetch with Relations (1 call)
+
+**Use `$expand=Relations` ONLY — do not include `fields`.**
+
+```bash
+node -e "
+const fs=require('fs'), os=require('os'), p=require('path');
+const wiql=JSON.parse(fs.readFileSync(p.join(os.homedir(),'ado-flow-tmp-wiql.json'),'utf8'));
+const ids=wiql.workItems.map(w=>w.id);
+console.log('Sprint items: '+ids.length);
+fs.writeFileSync(p.join(os.homedir(),'ado-flow-tmp-batch-body.json'),
+  JSON.stringify({ids: ids, '\$expand': 'Relations'}));
+"
+```
+
+```bash
+az rest --method post \
+  --url "https://dev.azure.com/{ORG}/{WI_PROJECT}/_apis/wit/workitemsbatch?api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  --body "@$HOME/ado-flow-tmp-batch-body.json" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-batch.json"
+```
+
+### 2c: Parse and Build Work Item + PR Link Maps
+
+Write a .js file for parsing:
+
+```javascript
+// Write this to $HOME/ado-flow-tmp-parse-wi.js
+const fs = require('fs'), p = require('path'), os = require('os');
+const home = os.homedir();
+const data = JSON.parse(fs.readFileSync(p.join(home, 'ado-flow-tmp-batch.json'), 'utf8'));
+
+const workItems = {}; // id -> { title, state }
+const linkedPrIds = new Set(); // PR IDs already linked to work items
+
+for (const wi of data.value) {
+  workItems[wi.id] = {
+    title: wi.fields['System.Title'],
+    state: wi.fields['System.State'],
+    type: wi.fields['System.WorkItemType']
+  };
+  if (wi.relations) {
+    for (const rel of wi.relations) {
+      if (rel.rel === 'ArtifactLink' && rel.attributes && rel.attributes.name === 'Pull Request') {
+        const prId = parseInt(rel.url.split('/').pop(), 10);
+        if (!isNaN(prId)) linkedPrIds.add(prId);
+      }
+    }
+  }
+}
+
+console.log('Work items: ' + Object.keys(workItems).length);
+console.log('Already linked PR IDs: ' + linkedPrIds.size);
+
+fs.writeFileSync(p.join(home, 'ado-flow-tmp-wi-parsed.json'),
+  JSON.stringify({ workItems, linkedPrIds: [...linkedPrIds] }));
+```
+
+```bash
+node "$HOME/ado-flow-tmp-parse-wi.js"
+```
+
+---
+
+## Phase 3: Fetch Sprint PRs (2 az calls)
+
+**Run 3a and 3b in parallel.**
+
+### 3a: Merged PRs (1 call)
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/{PR_PROJECT}/_apis/git/pullrequests?searchCriteria.creatorId={USER_ID}&searchCriteria.status=completed&searchCriteria.minTime={SPRINT_START}T00:00:00Z&searchCriteria.queryTimeRangeType=closed&\$top=30&api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-merged-prs.json"
+```
+
+### 3b: Active PRs (1 call)
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/{PR_PROJECT}/_apis/git/pullrequests?searchCriteria.creatorId={USER_ID}&searchCriteria.status=active&searchCriteria.minTime={SPRINT_START}T00:00:00Z&\$top=20&api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-active-prs.json"
+```
+
+Client-side: filter out `isDraft == true` from both.
+
+---
+
+## Phase 4: Match Unlinked PRs to Work Items (0 az calls)
+
+Write a .js file to identify unlinked PRs and match them:
+
+```javascript
+// Write this to $HOME/ado-flow-tmp-match.js
+const fs = require('fs'), p = require('path'), os = require('os');
+const home = os.homedir();
+
+function readJson(name) {
+  try { return JSON.parse(fs.readFileSync(p.join(home, name), 'utf8')); }
+  catch { return null; }
+}
+
+const wiData = readJson('ado-flow-tmp-wi-parsed.json');
+const mergedPrs = readJson('ado-flow-tmp-merged-prs.json');
+const activePrs = readJson('ado-flow-tmp-active-prs.json');
+
+const linkedPrIds = new Set(wiData.linkedPrIds);
+const wiIds = new Set(Object.keys(wiData.workItems).map(Number));
+
+// Combine all PRs, filter out already-linked and drafts
+const allPrs = [
+  ...((mergedPrs?.value || []).filter(pr => !pr.isDraft)),
+  ...((activePrs?.value || []).filter(pr => !pr.isDraft))
+];
+
+const unlinkedPrs = allPrs.filter(pr => !linkedPrIds.has(pr.pullRequestId));
+
+if (unlinkedPrs.length === 0) {
+  console.log(JSON.stringify({ unlinked: [], confident: [], fuzzy: [], noMatch: [] }));
+  process.exit(0);
+}
+
+// --- Matching strategies (most to least reliable) ---
+
+function extractIdsFromText(text) {
+  if (!text) return [];
+  const patterns = [
+    /(?:AB)?#(\d{4,7})\b/g,     // #1234 or AB#1234
+    /\bWI\s*(\d{4,7})\b/gi,     // WI 1234 or WI1234
+    /\b(\d{4,7})\b/g            // bare numbers (only used in branch names)
+  ];
+  const ids = new Set();
+  for (const pat of patterns) {
+    let m;
+    while ((m = pat.exec(text)) !== null) {
+      const id = parseInt(m[1], 10);
+      if (wiIds.has(id)) ids.add(id);
+    }
+  }
+  return [...ids];
+}
+
+// Strategy 1: Branch name parsing
+function matchByBranch(pr) {
+  const branch = pr.sourceRefName?.replace('refs/heads/', '') || '';
+  // Split by / and - to find numeric segments
+  const segments = branch.split(/[\/\-_]/);
+  for (const seg of segments) {
+    const id = parseInt(seg, 10);
+    if (!isNaN(id) && wiIds.has(id)) return { id, source: 'branch', branch };
+  }
+  // Also try regex on full branch name
+  const ids = extractIdsFromText(branch);
+  if (ids.length > 0) return { id: ids[0], source: 'branch', branch };
+  return null;
+}
+
+// Strategy 2: PR title/description mentions
+function matchByTitleDesc(pr) {
+  const titleIds = extractIdsFromText(pr.title);
+  if (titleIds.length > 0) return { id: titleIds[0], source: 'title' };
+  const descIds = extractIdsFromText(pr.description);
+  if (descIds.length > 0) return { id: descIds[0], source: 'description' };
+  return null;
+}
+
+// Strategy 3: Fuzzy title matching (token overlap, threshold >= 0.3)
+// Tokenizes both titles into words > 2 chars, computes overlap ratio.
+// A score of 0.3 means at least 30% of significant words are shared.
+// Below 0.3 = "No match". These are shown for individual confirmation.
+function fuzzyMatch(prTitle) {
+  const prWords = prTitle.toLowerCase().replace(/[^a-z0-9\s]/g, '').split(/\s+/).filter(w => w.length > 2);
+  let bestMatch = null;
+  let bestScore = 0;
+
+  for (const [idStr, wi] of Object.entries(wiData.workItems)) {
+    const wiWords = wi.title.toLowerCase().replace(/[^a-z0-9\s]/g, '').split(/\s+/).filter(w => w.length > 2);
+    const common = prWords.filter(w => wiWords.includes(w)).length;
+    const score = common / Math.max(prWords.length, wiWords.length);
+    if (score > bestScore && score >= 0.3) {
+      bestScore = score;
+      bestMatch = { id: parseInt(idStr, 10), title: wi.title, score };
+    }
+  }
+  return bestMatch;
+}
+
+const confident = [];
+const fuzzy = [];
+const noMatch = [];
+
+for (const pr of unlinkedPrs) {
+  const branchMatch = matchByBranch(pr);
+  if (branchMatch) {
+    confident.push({ pr, matchedWiId: branchMatch.id, source: branchMatch.source, detail: branchMatch.branch || '' });
+    continue;
+  }
+
+  const titleMatch = matchByTitleDesc(pr);
+  if (titleMatch) {
+    confident.push({ pr, matchedWiId: titleMatch.id, source: titleMatch.source, detail: '' });
+    continue;
+  }
+
+  const fuzzyResult = fuzzyMatch(pr.title);
+  if (fuzzyResult) {
+    fuzzy.push({ pr, matchedWiId: fuzzyResult.id, matchedTitle: fuzzyResult.title, score: fuzzyResult.score });
+    continue;
+  }
+
+  noMatch.push({ pr });
+}
+
+console.log(JSON.stringify({ confident, fuzzy, noMatch }));
+```
+
+```bash
+node "$HOME/ado-flow-tmp-match.js"
+```
+
+---
+
+## Phase 5: Present Matches and Confirm (0 az calls)
+
+Present the matches in this format:
+
+> **Unlinked PRs in {MONTH_NAME} sprint:**
+>
+> **Confident matches (from branch/title):**
+> 1. PR !{ID} "{TITLE}" (branch: {BRANCH}) -> #{WI_ID} {WI_TITLE}
+> 2. PR !{ID} "{TITLE}" (title mentions #{WI_ID}) -> #{WI_ID} {WI_TITLE}
+>
+> **Fuzzy matches (title similarity):**
+> 3. PR !{ID} "{TITLE}" -> likely #{WI_ID} ({WI_TITLE})?
+>
+> **No match found:**
+> 4. PR !{ID} "{TITLE}"
+>
+> Link? **[a]**ll-confident **[1-6]** individually **[s]**kip-all
+
+If there are no unlinked PRs:
+> All PRs in the sprint are already linked. Nothing to do.
+
+---
+
+## Phase 6: Apply Links (N az calls)
+
+**Requires permissions:** `vso.code_write` (to modify PRs) and `vso.work_write` (to create work item links). If the user's token lacks these scopes, the link calls will return 403.
+
+**Rate-limit warning:** If more than 10 links will be applied, warn the user before proceeding: "About to create {N} links. Continue? (y/n)". This prevents unexpected bulk writes.
+
+For each confirmed link, use `az repos pr work-item add`:
+
+```bash
+az repos pr work-item add \
+  --org "https://dev.azure.com/{ORG}" \
+  --id {PR_ID} \
+  --work-items {WI_ID} \
+  --detect false 2>/dev/null
+```
+
+**One call per link.** Log results inline:
+
+> PR !{PR_ID} -> #{WI_ID} linked
+> PR !{PR_ID} -> #{WI_ID} FAILED: {error}
+
+**Error handling:** Log inline, continue batch. Never abort.
+
+---
+
+## Phase 7: Summary + Cleanup
+
+> Link-PRs done. {N} linked, {M} skipped, {J} no match.
+> `{CALL_COUNT} API calls | {PR_COUNT} PRs checked | ~{ELAPSED}s`
+
+```bash
+rm -f "$HOME"/ado-flow-tmp-*.json "$HOME"/ado-flow-tmp-*.js 2>/dev/null
+```
+
+---
+
+## Expected Call Counts
+
+| Phase | First run | Cached run |
+|-------|-----------|------------|
+| Identity | 1 | 0 |
+| Sprint detection | 0 | 0 |
+| WIQL (sprint items) | 1 | 1 |
+| Batch + Relations | 1 | 1 |
+| Merged PRs | 1 | 1 |
+| Active PRs | 1 | 1 |
+| **Total (data)** | **6** | **5** |
+| Linking | N | N |
+
+**You MUST output the diagnostic line in the match presentation AND in the final summary.**
+
+---
+
+## Communication Style
+
+- **Show matches first, ask second.** Present the full table, then ask for confirmation.
+- **Confident = bulk linkable.** One prompt: "Link all {N} confident matches? [a]ll / [s]kip". User says "a" to link all at once.
+- **Fuzzy = individual confirmation.** Each fuzzy match gets its own yes/no prompt: "Link PR !{ID} to #{WI_ID}? [y/n]".
+- **No match = info only.** Show them but don't prompt for action.
+- **Single-line results.** `PR !{ID} -> #{WI_ID} linked` — no filler.
+- **Errors don't abort.** Log inline, continue, report at end.
+- **Target: under 30 seconds for data collection, plus user confirmation time.**

--- a/plugins/ado-flow/commands/morning.md
+++ b/plugins/ado-flow/commands/morning.md
@@ -1,0 +1,446 @@
+---
+name: adoflow:morning
+description: Morning briefing — review queue, your PR status, sprint progress, pipeline health, and action items
+argument-hint: "[morning briefing | what should I work on | daily overview]"
+---
+
+# Azure DevOps Morning Briefing
+
+Combines your review queue, PR status, sprint progress, pipeline health, and prioritized action items into one view.
+
+## Arguments
+
+<user_request> $ARGUMENTS </user_request>
+
+**If empty, proceed with default workflow.**
+
+---
+
+## Hard Rules
+
+1. **All data-fetching uses `az rest`.** Do not use `az boards query`, `az boards work-item show`, `az repos pr list`, or `az boards iteration *` for fetching.
+2. **Always write az output to a file.** Pattern: `az rest ... -o json 2>/dev/null > "$HOME/ado-flow-tmp-{name}.json"`. Windows `az` CLI emits encoding warnings that corrupt inline JSON.
+3. **For scripts longer than 3 lines, write to a .js file** and run with `node "$HOME/ado-flow-tmp-{name}.js"`. Do not use `node -e` for complex scripts — backslash escaping breaks on Windows. For 1-3 line scripts, `node -e` is fine.
+4. **Never use `python3` or `python`.** Never pipe into node via stdin. Always read from files.
+5. **Never use `/tmp/`.** It resolves to `C:\tmp\` in Node.js on Windows. Use `$HOME/ado-flow-tmp-*` for all temp files.
+6. **Never run data-collection in the background.** All data must be collected before presenting the briefing.
+7. **Do not use `$expand` and `fields` together** in the batch API. They conflict. Use `$expand=Relations` alone — it returns all fields automatically.
+8. **connectionData API requires `api-version=7.1-preview`** (not `7.1`).
+9. **Clean up temp files** at the end: `rm -f "$HOME"/ado-flow-tmp-*.json "$HOME"/ado-flow-tmp-*.js 2>/dev/null`
+10. **This command is read-only.** No writes to Azure DevOps.
+
+---
+
+## Phase 0: Load Config (0 az calls)
+
+```bash
+cat "$HOME/.config/ado-flow/config.json" 2>/dev/null
+```
+
+If no config exists, follow the `ado-flow` skill for first-time setup.
+
+**Accept both key formats:** `organization` or `ORG`, `work_item_project` or `WORK_ITEM_PROJECT`, `pr_project` or `PR_PROJECT`.
+
+Map to: `{ORG}`, `{WI_PROJECT}`, `{PR_PROJECT}`.
+
+Also check for cached: `user_id` (GUID), `user_email`.
+
+### Project Routing Rule
+
+| API | Project |
+|-----|---------|
+| `_apis/wit/*` (WIQL, batch, work items) | `{WI_PROJECT}` |
+| `_apis/git/pullrequests` | `{PR_PROJECT}` |
+| `_apis/build/builds` | `{PR_PROJECT}` |
+
+**Never swap.** `{WI_PROJECT}` and `{PR_PROJECT}` may be different.
+
+---
+
+## Phase 1: Resolve Identity + Compute Sprint (0-1 az calls)
+
+### 1a: User Identity (0-1 calls, cached)
+
+Check config for `user_id` and `user_email`. **If both present, skip.**
+
+If missing (1 call):
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/_apis/connectionData?api-version=7.1-preview" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-conn.json"
+```
+
+Extract `authenticatedUser.id` -> `{USER_ID}` (GUID). If email not in response, get via `az account show --query "user.name" -o tsv 2>/dev/null`.
+
+**Cache immediately** in config.
+
+### 1b: Compute Sprint from Today's Date (0 calls)
+
+The iteration path follows a fixed format: `{WI_PROJECT}\{year}\H{half}\Q{quarter}\{month_name}`.
+
+**Compute it from today's date — no API call needed:**
+
+```javascript
+const now = new Date();
+const year = now.getFullYear();
+const month = now.getMonth(); // 0-indexed
+const monthNames = ['January','February','March','April','May','June',
+                    'July','August','September','October','November','December'];
+const quarter = Math.floor(month / 3) + 1; // Q1-Q4
+const half = month < 6 ? 1 : 2; // H1 or H2
+
+const iterationPath = `{WI_PROJECT}\\${year}\\H${half}\\Q${quarter}\\${monthNames[month]}`;
+
+// Sprint dates = first and last day of the current month
+const sprintStart = `${year}-${String(month+1).padStart(2,'0')}-01`;
+const lastDay = new Date(year, month+1, 0).getDate();
+const sprintEnd = `${year}-${String(month+1).padStart(2,'0')}-${lastDay}`;
+```
+
+Store: `{CURRENT_ITERATION}`, `{SPRINT_START}`, `{SPRINT_END}`.
+
+Compute yesterday's date for time filters:
+
+```javascript
+const yesterday = new Date();
+yesterday.setDate(yesterday.getDate() - 1);
+const minTime = yesterday.toISOString().split('T')[0] + 'T00:00:00Z';
+```
+
+Store: `{YESTERDAY_ISO}`.
+
+---
+
+## Phase 2: Fetch Review Queue + My PRs (2 az calls, run in parallel)
+
+### 2a: PRs Awaiting My Review (1 call)
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/{PR_PROJECT}/_apis/git/pullrequests?searchCriteria.reviewerId={USER_ID}&searchCriteria.status=active&\$top=20&api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-review-queue.json"
+```
+
+Client-side filter: only include PRs where my vote == 0 (haven't reviewed yet) or vote == -5 (waiting for author, but author has pushed new changes). Exclude PRs created by me.
+
+### 2b: My Active PRs (1 call)
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/{PR_PROJECT}/_apis/git/pullrequests?searchCriteria.creatorId={USER_ID}&searchCriteria.status=active&\$top=20&api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-my-prs.json"
+```
+
+---
+
+## Phase 3: Fetch Sprint Work Items (2 az calls)
+
+### 3a: WIQL Query — Sprint Items (1 call)
+
+```bash
+node -e "
+const fs=require('fs'), os=require('os'), p=require('path');
+fs.writeFileSync(p.join(os.homedir(),'ado-flow-tmp-wiql-body.json'),
+  JSON.stringify({query: \"SELECT [System.Id] FROM workitems WHERE [System.AssignedTo] = @me AND [System.IterationPath] = '{CURRENT_ITERATION}' ORDER BY [System.State] ASC\"}));
+"
+```
+
+```bash
+az rest --method post \
+  --url "https://dev.azure.com/{ORG}/{WI_PROJECT}/_apis/wit/wiql?api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  --body "@$HOME/ado-flow-tmp-wiql-body.json" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-wiql.json"
+```
+
+### 3b: Batch Fetch (1 call)
+
+**Only if WIQL returned results.** Use `$expand=Relations` ONLY.
+
+```bash
+node -e "
+const fs=require('fs'), os=require('os'), p=require('path');
+const wiql=JSON.parse(fs.readFileSync(p.join(os.homedir(),'ado-flow-tmp-wiql.json'),'utf8'));
+const ids=wiql.workItems.map(w=>w.id);
+console.log('Sprint items: '+ids.length);
+if(ids.length===0){process.exit(0);}
+fs.writeFileSync(p.join(os.homedir(),'ado-flow-tmp-batch-body.json'),
+  JSON.stringify({ids: ids, '\$expand': 'Relations'}));
+"
+```
+
+```bash
+az rest --method post \
+  --url "https://dev.azure.com/{ORG}/{WI_PROJECT}/_apis/wit/workitemsbatch?api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  --body "@$HOME/ado-flow-tmp-batch-body.json" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-batch.json"
+```
+
+---
+
+## Phase 4: Fetch Pipeline Builds (1 az call)
+
+### 4a: Recent Builds by Me (1 call)
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/{PR_PROJECT}/_apis/build/builds?requestedFor={USER_EMAIL}&minTime={YESTERDAY_ISO}&\$top=10&api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-builds.json"
+```
+
+**Note:** Use `{USER_EMAIL}` for `requestedFor` (display name or email, not GUID). If that returns 0 results, the filter may need `requestedFor` as display name — log but don't fail.
+
+---
+
+## Phase 5: Build and Present Briefing (0 az calls)
+
+Write a .js file to parse all collected data and generate the briefing:
+
+```javascript
+// Write this to $HOME/ado-flow-tmp-morning.js
+const fs = require('fs'), p = require('path'), os = require('os');
+const home = os.homedir();
+
+function readJson(name) {
+  try { return JSON.parse(fs.readFileSync(p.join(home, name), 'utf8')); }
+  catch { return null; }
+}
+
+// Load user_id from config — do NOT hardcode the GUID as a string literal
+const config = JSON.parse(fs.readFileSync(p.join(home, '.config', 'ado-flow', 'config.json'), 'utf8'));
+const userId = config.user_id;
+
+const reviewQueueRaw = readJson('ado-flow-tmp-review-queue.json');
+const myPrsRaw = readJson('ado-flow-tmp-my-prs.json');
+const batch = readJson('ado-flow-tmp-batch.json');
+const buildsRaw = readJson('ado-flow-tmp-builds.json');
+
+const now = new Date();
+const STALE_DAYS = 14;
+
+function daysAgo(dateStr) {
+  return Math.floor((now - new Date(dateStr)) / 86400000);
+}
+function relativeTime(dateStr) {
+  const d = daysAgo(dateStr);
+  if (d === 0) return 'today';
+  if (d === 1) return 'yesterday';
+  return `${d}d ago`;
+}
+
+// --- Review Queue: PRs where my vote == 0, not created by me, sorted oldest first ---
+const reviewQueue = [];
+if (reviewQueueRaw && reviewQueueRaw.value) {
+  for (const pr of reviewQueueRaw.value) {
+    if (pr.createdBy && pr.createdBy.id === userId) continue;
+    const myReview = (pr.reviewers || []).find(r => r.id === userId);
+    if (!myReview || myReview.vote === 0) {
+      const waiting = daysAgo(pr.creationDate);
+      reviewQueue.push({ id: pr.pullRequestId, title: pr.title,
+        author: pr.createdBy?.displayName || 'unknown', waiting, urgent: waiting >= 3 });
+    }
+  }
+  reviewQueue.sort((a, b) => b.waiting - a.waiting); // oldest first
+}
+
+// --- My PRs: summarize review status ---
+const myPrs = [];
+if (myPrsRaw && myPrsRaw.value) {
+  for (const pr of myPrsRaw.value) {
+    if (pr.isDraft) continue;
+    const reviewers = pr.reviewers || [];
+    const approvals = reviewers.filter(r => r.vote >= 5).length;
+    const rejections = reviewers.filter(r => r.vote <= -5);
+    let status;
+    if (rejections.length > 0) {
+      status = `changes requested by @${rejections[0].displayName}`;
+    } else if (approvals > 0 && rejections.length === 0) {
+      status = `${approvals} approval${approvals > 1 ? 's' : ''}, ready to merge`;
+    } else {
+      status = 'awaiting review';
+    }
+    myPrs.push({ id: pr.pullRequestId, title: pr.title, status });
+  }
+}
+
+// --- Sprint Progress: categorize by state ---
+const doneStates = new Set(['Closed', 'Done', 'Resolved', 'Completed']);
+const activeStates = new Set(['Active', 'In Progress', 'Committed', 'Open']);
+const newStates = new Set(['New', 'To Do', 'Proposed']);
+let done = 0, inProgress = 0, notStarted = 0, needsAttention = 0, total = 0;
+const staleItems = [];
+if (batch && batch.value) {
+  total = batch.value.length;
+  for (const wi of batch.value) {
+    const f = wi.fields;
+    const state = f['System.State'];
+    const tags = (f['System.Tags'] || '').toLowerCase();
+    const stale = daysAgo(f['System.ChangedDate']) > STALE_DAYS;
+    if (stale || tags.includes('blocked')) {
+      needsAttention++;
+      staleItems.push({ id: wi.id, title: f['System.Title'],
+        days: daysAgo(f['System.ChangedDate']), blocked: tags.includes('blocked') });
+    } else if (doneStates.has(state)) { done++; }
+    else if (activeStates.has(state)) { inProgress++; }
+    else if (newStates.has(state)) { notStarted++; }
+    else { notStarted++; }
+  }
+}
+const pct = total > 0 ? Math.round(done / total * 100) : 0;
+const barLen = 16;
+const filled = Math.round(pct / 100 * barLen);
+const progressBar = '\u2588'.repeat(filled) + '\u2591'.repeat(barLen - filled);
+
+// --- Pipelines: format results ---
+const pipelines = [];
+if (buildsRaw && buildsRaw.value) {
+  for (const b of buildsRaw.value) {
+    const emoji = b.result === 'succeeded' ? '\u2705' :
+                  b.result === 'failed' ? '\u274C' :
+                  b.result === 'partiallySucceeded' ? '\u26A0\uFE0F' :
+                  b.result === 'canceled' ? '\u23F9' :
+                  b.status === 'inProgress' ? '\u23F3' : '\u2753';
+    pipelines.push({ name: b.definition?.name || 'unknown', number: b.buildNumber,
+      emoji, result: b.result || b.status, branch: b.sourceBranch?.replace('refs/heads/', '') || '',
+      time: relativeTime(b.finishTime || b.startTime) });
+  }
+}
+
+// --- Action Items: auto-prioritized ---
+const actions = [];
+for (const pr of reviewQueue) {
+  actions.push(`Review PR !${pr.id} (waiting ${pr.waiting}d${pr.urgent ? ' — blocking @' + pr.author : ''})`);
+}
+for (const p of pipelines) {
+  if (p.result === 'failed') {
+    actions.push(`Check pipeline failure: ${p.name} on ${p.branch}`);
+  }
+}
+if (staleItems.length > 0) {
+  const ids = staleItems.map(s => '#' + s.id).join(', ');
+  actions.push(`${staleItems.length} stale item${staleItems.length > 1 ? 's' : ''} need attention (${ids})`);
+}
+for (const pr of myPrs) {
+  if (pr.status.includes('ready to merge')) {
+    actions.push(`Merge PR !${pr.id} (${pr.title})`);
+  }
+}
+
+console.log(JSON.stringify({
+  reviewQueue, myPrs, sprint: { total, done, inProgress, notStarted, needsAttention, pct, progressBar },
+  pipelines, staleItems, actions
+}));
+```
+
+```bash
+node "$HOME/ado-flow-tmp-morning.js"
+```
+
+### Output Format
+
+Present the briefing in this exact format:
+
+> **Morning Briefing — {DATE}**
+>
+> **Review Queue ({N} PRs waiting for you):**
+> - PR !{ID} "{TITLE}" by @{AUTHOR} — waiting {N}d {WARNING_IF_3D+}
+> - PR !{ID} "{TITLE}" by @{AUTHOR} — waiting {N}d
+>
+> **Your PRs:**
+> - PR !{ID} "{TITLE}" — {APPROVALS} approvals, ready to merge
+> - PR !{ID} "{TITLE}" — changes requested by @{REVIEWER}
+> - PR !{ID} "{TITLE}" — merged yesterday
+>
+> **Sprint Progress ({MONTH_NAME}):**
+> - {TOTAL} items: {DONE} done, {IN_PROGRESS} in progress, {NOT_STARTED} not started, {NEEDS_ATTENTION} need attention
+> - {PROGRESS_BAR} {PERCENT}% complete
+>
+> **Pipelines:**
+> - {PIPELINE_NAME} #{BUILD_NUMBER} — {RESULT_EMOJI} {RESULT} ({BRANCH}, {TIME_AGO})
+>
+> **Action items:**
+> 1. Review PR !{ID} (waiting {N}d — blocking @{AUTHOR})
+> 2. Check pipeline failure on {BRANCH}
+> 3. {N} stale items need attention (#{ID}, #{ID})
+>
+> `{CALL_COUNT} API calls | ~{ELAPSED}s`
+
+### Building Each Section
+
+**Review Queue:** PRs from Phase 2a where my vote == 0, excluding PRs I created. Sort by creation date ascending (oldest first = most urgent). Add warning emoji for PRs waiting 3+ days. Exclude draft PRs.
+
+**Your PRs:** PRs from Phase 2b. Summarize review status:
+- All approvals, no rejections -> "ready to merge"
+- Has rejections or "wait for author" -> "changes requested by @{name}"
+- No reviews yet -> "awaiting review"
+
+**Sprint Progress:** From Phase 3 batch data. Categorize by state:
+- Done states: Closed, Done, Resolved, Completed -> done
+- Active states: Active, In Progress, Committed, Open -> in progress
+- New states: New, To Do, Proposed -> not started
+- Stale (>14d no change) or tagged "Blocked" -> need attention
+
+Progress bar: 16 chars wide, filled proportionally. `done / total * 100` = percent.
+
+```
+Progress bar chars: filled = █ (U+2588, FULL BLOCK), empty = ░ (U+2591, LIGHT SHADE)
+Example: ██████░░░░░░░░░░ 37% complete
+```
+
+**Pipelines:** From Phase 4. Show result with emoji:
+- `succeeded` -> green checkmark
+- `failed` -> red X
+- `partiallySucceeded` -> warning
+- `canceled` -> canceled
+- `inProgress` -> running
+
+Show branch name and relative time ("2h ago", "yesterday").
+
+**Action Items:** Automatically prioritized list:
+1. PRs waiting for my review (oldest first, especially 3+ days)
+2. Pipeline failures on my branches
+3. Stale work items (>14d no change)
+4. PRs ready to merge (just need the button click)
+
+If a section has 0 items, omit it entirely (except Sprint Progress, always show that).
+
+---
+
+## Phase 6: Cleanup
+
+```bash
+rm -f "$HOME"/ado-flow-tmp-*.json "$HOME"/ado-flow-tmp-*.js 2>/dev/null
+```
+
+---
+
+## Expected Call Counts
+
+| Phase | First run | Cached run |
+|-------|-----------|------------|
+| Identity | 1 | 0 |
+| Sprint detection | 0 | 0 |
+| Review queue PRs | 1 | 1 |
+| My active PRs | 1 | 1 |
+| WIQL (sprint items) | 1 | 1 |
+| Batch fetch | 1 | 1 |
+| Pipeline builds | 1 | 1 |
+| **Total (data)** | **6** | **5** |
+
+**You MUST output the diagnostic line at the end of the briefing.**
+
+---
+
+## Communication Style
+
+- **Generate first, don't ask.** Output the full briefing immediately — no prompts.
+- **Action items are the hook.** The numbered list at the bottom tells the developer what to do first.
+- **Compact but complete.** Every section is a quick scan. No paragraphs.
+- **Emoji for quick scanning.** Red/green/warning indicators for pipeline status and review urgency.
+- **Target: under 45 seconds, 0 developer inputs.**

--- a/plugins/ado-flow/commands/standup.md
+++ b/plugins/ado-flow/commands/standup.md
@@ -1,0 +1,367 @@
+---
+name: adoflow:standup
+description: Generate a daily standup summary from Azure DevOps activity — work items changed, PRs created/reviewed, blockers
+argument-hint: "[generate my standup | daily standup | what did I do yesterday]"
+---
+
+# Azure DevOps Daily Standup
+
+Generates a copy-paste-ready standup from your last 24 hours of Azure DevOps activity.
+
+## Arguments
+
+<user_request> $ARGUMENTS </user_request>
+
+**If empty, proceed with default workflow.**
+
+---
+
+## Hard Rules
+
+1. **All data-fetching uses `az rest`.** Do not use `az boards query`, `az boards work-item show`, `az repos pr list`, or `az boards iteration *` for fetching.
+2. **Always write az output to a file.** Pattern: `az rest ... -o json 2>/dev/null > "$HOME/ado-flow-tmp-{name}.json"`. Windows `az` CLI emits encoding warnings that corrupt inline JSON.
+3. **For scripts longer than 3 lines, write to a .js file** and run with `node "$HOME/ado-flow-tmp-{name}.js"`. Do not use `node -e` for complex scripts — backslash escaping breaks on Windows. For 1-3 line scripts, `node -e` is fine.
+4. **Never use `python3` or `python`.** Never pipe into node via stdin. Always read from files.
+5. **Never use `/tmp/`.** It resolves to `C:\tmp\` in Node.js on Windows. Use `$HOME/ado-flow-tmp-*` for all temp files.
+6. **Never run data-collection in the background.** All data must be collected before presenting the standup.
+7. **Do not use `$expand` and `fields` together** in the batch API. They conflict. Use `$expand=Relations` alone — it returns all fields automatically.
+8. **connectionData API requires `api-version=7.1-preview`** (not `7.1`).
+9. **Clean up temp files** at the end: `rm -f "$HOME"/ado-flow-tmp-*.json "$HOME"/ado-flow-tmp-*.js 2>/dev/null`
+10. **This command is read-only.** No writes to Azure DevOps.
+
+---
+
+## Phase 0: Load Config (0 az calls)
+
+```bash
+cat "$HOME/.config/ado-flow/config.json" 2>/dev/null
+```
+
+If no config exists, follow the `ado-flow` skill for first-time setup.
+
+**Accept both key formats:** `organization` or `ORG`, `work_item_project` or `WORK_ITEM_PROJECT`, `pr_project` or `PR_PROJECT`.
+
+Map to: `{ORG}`, `{WI_PROJECT}`, `{PR_PROJECT}`.
+
+Also check for cached: `user_id` (GUID), `user_email`.
+
+### Project Routing Rule
+
+| API | Project |
+|-----|---------|
+| `_apis/wit/*` (WIQL, batch, work items) | `{WI_PROJECT}` |
+| `_apis/git/pullrequests` | `{PR_PROJECT}` |
+
+**Never swap.** `{WI_PROJECT}` and `{PR_PROJECT}` may be different.
+
+---
+
+## Phase 1: Resolve Identity + Compute Sprint (0-1 az calls)
+
+### 1a: User Identity (0-1 calls, cached)
+
+Check config for `user_id` and `user_email`. **If both present, skip.**
+
+If missing (1 call):
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/_apis/connectionData?api-version=7.1-preview" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-conn.json"
+```
+
+Extract `authenticatedUser.id` -> `{USER_ID}` (GUID). If email not in response, get via `az account show --query "user.name" -o tsv 2>/dev/null`.
+
+**Cache immediately** in config.
+
+### 1b: Compute Sprint from Today's Date (0 calls)
+
+The iteration path follows a fixed format: `{WI_PROJECT}\{year}\H{half}\Q{quarter}\{month_name}`.
+
+**Compute it from today's date — no API call needed:**
+
+```javascript
+const now = new Date();
+const year = now.getFullYear();
+const month = now.getMonth(); // 0-indexed
+const monthNames = ['January','February','March','April','May','June',
+                    'July','August','September','October','November','December'];
+const quarter = Math.floor(month / 3) + 1; // Q1-Q4
+const half = month < 6 ? 1 : 2; // H1 or H2
+
+const iterationPath = `{WI_PROJECT}\\${year}\\H${half}\\Q${quarter}\\${monthNames[month]}`;
+```
+
+Store: `{CURRENT_ITERATION}`.
+
+---
+
+## Phase 2: Fetch Work Items Changed in Last 24h (2 az calls)
+
+### 2a: WIQL Query — Items Changed Yesterday (1 call)
+
+```bash
+node -e "
+const fs=require('fs'), os=require('os'), p=require('path');
+fs.writeFileSync(p.join(os.homedir(),'ado-flow-tmp-wiql-body.json'),
+  JSON.stringify({query: \"SELECT [System.Id] FROM workitems WHERE [System.AssignedTo] = @me AND [System.ChangedDate] >= @today - 1 ORDER BY [System.ChangedDate] DESC\"}));
+"
+```
+
+```bash
+az rest --method post \
+  --url "https://dev.azure.com/{ORG}/{WI_PROJECT}/_apis/wit/wiql?api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  --body "@$HOME/ado-flow-tmp-wiql-body.json" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-wiql.json"
+```
+
+### 2b: Batch Fetch with Relations (1 call)
+
+**Only if WIQL returned results.** Use `$expand=Relations` ONLY — do not include `fields`.
+
+```bash
+node -e "
+const fs=require('fs'), os=require('os'), p=require('path');
+const wiql=JSON.parse(fs.readFileSync(p.join(os.homedir(),'ado-flow-tmp-wiql.json'),'utf8'));
+const ids=wiql.workItems.map(w=>w.id);
+console.log('Changed items: '+ids.length);
+if(ids.length===0){process.exit(0);}
+fs.writeFileSync(p.join(os.homedir(),'ado-flow-tmp-batch-body.json'),
+  JSON.stringify({ids: ids, '\$expand': 'Relations'}));
+"
+```
+
+```bash
+az rest --method post \
+  --url "https://dev.azure.com/{ORG}/{WI_PROJECT}/_apis/wit/workitemsbatch?api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  --body "@$HOME/ado-flow-tmp-batch-body.json" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-batch.json"
+```
+
+---
+
+## Phase 3: Fetch PRs from Last 24h (1-2 az calls)
+
+Compute yesterday's date for the `minTime` filter:
+
+```javascript
+const yesterday = new Date();
+yesterday.setDate(yesterday.getDate() - 1);
+const minTime = yesterday.toISOString().split('T')[0] + 'T00:00:00Z';
+```
+
+### 3a: PRs Created by Me (1 call)
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/{PR_PROJECT}/_apis/git/pullrequests?searchCriteria.creatorId={USER_ID}&searchCriteria.status=all&searchCriteria.minTime={YESTERDAY}T00:00:00Z&\$top=20&api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-my-prs.json"
+```
+
+### 3b: PRs I Reviewed (1 call)
+
+```bash
+az rest --method get \
+  --url "https://dev.azure.com/{ORG}/{PR_PROJECT}/_apis/git/pullrequests?searchCriteria.reviewerId={USER_ID}&searchCriteria.status=all&searchCriteria.minTime={YESTERDAY}T00:00:00Z&\$top=20&api-version=7.1" \
+  --resource "499b84ac-1321-427f-aa17-267ca6975798" \
+  -o json 2>/dev/null > "$HOME/ado-flow-tmp-reviewed-prs.json"
+```
+
+---
+
+## Phase 4: Fetch Current Sprint Active Items for "Today" Section (0-1 az calls)
+
+If Phase 2 already fetched sprint items with `{CURRENT_ITERATION}` filter, reuse that data. Otherwise, run a WIQL for current sprint active items:
+
+```bash
+node -e "
+const fs=require('fs'), os=require('os'), p=require('path');
+fs.writeFileSync(p.join(os.homedir(),'ado-flow-tmp-today-body.json'),
+  JSON.stringify({query: \"SELECT [System.Id] FROM workitems WHERE [System.AssignedTo] = @me AND [System.IterationPath] = '{CURRENT_ITERATION}' AND [System.State] NOT IN ('Closed','Done','Resolved','Removed','Completed') ORDER BY [System.ChangedDate] DESC\"}));
+"
+```
+
+If not already fetched, run the WIQL + batch fetch. Otherwise, filter the Phase 2 batch data to items in `{CURRENT_ITERATION}` with active states.
+
+---
+
+## Phase 5: Build and Present Standup (0 az calls)
+
+Write a .js file to parse all collected data and generate the standup:
+
+```javascript
+// Write this to $HOME/ado-flow-tmp-standup.js
+const fs = require('fs'), p = require('path'), os = require('os');
+const home = os.homedir();
+
+function readJson(name) {
+  try { return JSON.parse(fs.readFileSync(p.join(home, name), 'utf8')); }
+  catch { return null; }
+}
+
+// Load user_id from config — do NOT hardcode the GUID as a string literal
+const config = JSON.parse(fs.readFileSync(p.join(home, '.config', 'ado-flow', 'config.json'), 'utf8'));
+const userId = config.user_id;
+
+const batch = readJson('ado-flow-tmp-batch.json');
+const myPrs = readJson('ado-flow-tmp-my-prs.json');
+const reviewedPrs = readJson('ado-flow-tmp-reviewed-prs.json');
+
+const STALE_DAYS = 14;
+const now = new Date();
+
+// --- Yesterday section ---
+const yesterday = [];
+
+// Work items changed
+if (batch && batch.value) {
+  for (const wi of batch.value) {
+    const f = wi.fields;
+    const state = f['System.State'];
+    const title = f['System.Title'];
+    yesterday.push(`- #${wi.id} "${title}" (${state})`);
+  }
+}
+
+// PRs I created/merged
+if (myPrs && myPrs.value) {
+  for (const pr of myPrs.value) {
+    const status = pr.status === 'completed' ? 'merged' :
+                   pr.status === 'abandoned' ? 'abandoned' : 'created';
+    yesterday.push(`- PR !${pr.pullRequestId} "${pr.title}" — ${status}`);
+  }
+}
+
+// PRs I reviewed
+if (reviewedPrs && reviewedPrs.value) {
+  const myPrIds = new Set((myPrs?.value || []).map(pr => pr.pullRequestId));
+  for (const pr of reviewedPrs.value) {
+    if (myPrIds.has(pr.pullRequestId)) continue; // skip my own
+    const myVote = (pr.reviewers || []).find(r => r.id === userId);
+    const voteLabel = !myVote ? 'reviewed' :
+                      myVote.vote === 10 ? 'approved' :
+                      myVote.vote === 5 ? 'approved with suggestions' :
+                      myVote.vote === -5 ? 'waiting for author' :
+                      myVote.vote === -10 ? 'rejected' : 'reviewed';
+    yesterday.push(`- Reviewed PR !${pr.pullRequestId} "${pr.title}" by @${pr.createdBy.displayName} (${voteLabel})`);
+  }
+}
+
+// --- Today section ---
+// Items in current sprint with active states (Active, In Progress, Committed, Open)
+const today = [];
+const activeStates = new Set(['Active', 'In Progress', 'Committed', 'Open']);
+if (batch && batch.value) {
+  const sprintItems = batch.value
+    .filter(wi => activeStates.has(wi.fields['System.State']))
+    .sort((a, b) => new Date(b.fields['System.ChangedDate']) - new Date(a.fields['System.ChangedDate']));
+  for (const wi of sprintItems) {
+    const f = wi.fields;
+    const daysAgo = Math.floor((now - new Date(f['System.ChangedDate'])) / 86400000);
+    const age = daysAgo <= 1 ? 'today' : `${daysAgo}d ago`;
+    today.push(`- #${wi.id} ${f['System.Title']} (${f['System.State']}, ${age})`);
+  }
+}
+// Active PRs awaiting review
+if (myPrs && myPrs.value) {
+  for (const pr of myPrs.value) {
+    if (pr.status === 'active' && !pr.isDraft) {
+      today.push(`- PR !${pr.pullRequestId} awaiting review (${pr.title})`);
+    }
+  }
+}
+
+// --- Blockers section ---
+// Items stale > STALE_DAYS or tagged "Blocked"
+const blockers = [];
+if (batch && batch.value) {
+  for (const wi of batch.value) {
+    const f = wi.fields;
+    const changedDate = new Date(f['System.ChangedDate']);
+    const daysStale = Math.floor((now - changedDate) / 86400000);
+    const tags = (f['System.Tags'] || '').toLowerCase();
+    if (daysStale > STALE_DAYS) {
+      blockers.push(`- #${wi.id} ${f['System.Title']} — stale ${daysStale}d, no activity`);
+    } else if (tags.includes('blocked')) {
+      blockers.push(`- #${wi.id} ${f['System.Title']} — tagged Blocked`);
+    }
+  }
+}
+
+console.log(JSON.stringify({ yesterday, today, blockers }));
+```
+
+### Output Format
+
+Present the standup in this exact format, copy-paste ready for Teams/Slack:
+
+```
+STANDUP_DATE = today's date formatted as "Mon DD, YYYY" (e.g., "Feb 21, 2026")
+```
+
+> **Standup — {STANDUP_DATE}**
+>
+> **Yesterday:**
+> - Merged PR !1478 "Add OAuth support" -> resolved #5162
+> - Moved #5169 to Active (OpenTelemetry trace propagation)
+> - Reviewed PR !1474 by @alice (approved)
+>
+> **Today:**
+> - #5172 AI recommendations not working (Active, assigned to me)
+> - #5147 Split models.py into package (Active, 10d ago)
+> - PR !1462 awaiting review (Fix SLA breach)
+>
+> **Blockers:**
+> - #4920 TMP Migration — stale 21d, no activity
+>
+> `{CALL_COUNT} API calls | ~{ELAPSED}s`
+
+### Building Each Section
+
+**Yesterday** = items from Phase 2 (changed in last 24h) + PRs from Phase 3 (created/merged/reviewed in last 24h). Deduplicate — if a work item was resolved via a merged PR, combine into one line like "Merged PR !{ID} -> resolved #{WI_ID}".
+
+**Today** = current sprint items in Active/In Progress/Committed/Open state from Phase 4. Show the most recently changed first. Include any active PRs awaiting review.
+
+**Blockers** = items from the sprint where:
+- `System.ChangedDate` is >14 days ago (stale), OR
+- `System.Tags` contains "Blocked"
+
+If a section is empty, omit it entirely.
+
+---
+
+## Phase 6: Cleanup
+
+```bash
+rm -f "$HOME"/ado-flow-tmp-*.json "$HOME"/ado-flow-tmp-*.js 2>/dev/null
+```
+
+---
+
+## Expected Call Counts
+
+| Phase | First run | Cached run |
+|-------|-----------|------------|
+| Identity | 1 | 0 |
+| Sprint detection | 0 | 0 |
+| WIQL (changed items) | 1 | 1 |
+| Batch fetch | 1 | 1 |
+| My PRs | 1 | 1 |
+| Reviewed PRs | 1 | 1 |
+| **Total (data)** | **5** | **4** |
+
+**You MUST output the diagnostic line at the end of the standup.**
+
+---
+
+## Communication Style
+
+- **Generate first, don't ask.** Output the standup immediately — no prompts before showing it.
+- **Copy-paste ready.** The output should work directly in Teams or Slack.
+- **One-liners.** Each item is a single line. No filler, no explanations.
+- **Empty sections omitted.** If no blockers, don't show the Blockers section.
+- **Target: under 30 seconds, 0 developer inputs.**


### PR DESCRIPTION
## Summary
- Add `/adoflow:standup` — generates copy-paste-ready daily standup from last 24h of Azure DevOps activity (work items changed, PRs created/reviewed, blockers)
- Add `/adoflow:link-prs` — finds unlinked PRs in the current sprint and matches them to work items via branch names, titles, and fuzzy matching
- Add `/adoflow:morning` — morning briefing combining review queue, PR status, sprint progress, pipeline health, and prioritized action items
- Bump ado-flow to v1.4.0 with updated plugin.json, README, and router

Also includes 20 documentation quality fixes from model-assisted review:
- Fix hardcoded `'{USER_ID}'` literal in standup voter matching (critical bug)
- Correct API call counts in README to match command files
- Fix Unicode character descriptions in morning progress bar
- Replace morning Phase 5 skeleton with full implementation
- Add `Mode` column (read-only / read/write) to README commands table
- Add `Caching` section to README
- Add required permissions docs for link-prs (`vso.code_write` + `vso.work_write`)
- Document fuzzy match algorithm (token overlap, >= 0.3 threshold)
- Add rate-limit warning for bulk link operations (>10 links)
- Add standup-vs-morning disambiguation rule in router
- Define "sorted by urgency" explicitly (oldest-first, 3+ days flagged)

## Test plan
- [ ] Run `/adoflow:standup` and verify Yesterday/Today/Blockers sections render correctly
- [ ] Run `/adoflow:link-prs` with known unlinked PRs and verify confident/fuzzy/no-match categorization
- [ ] Run `/adoflow:morning` and verify all 5 sections (review queue, PRs, sprint, pipelines, actions) populate
- [ ] Run `/adoflow standup` (via router) and verify it routes to standup workflow
- [ ] Run `/adoflow morning briefing` (via router) and verify it routes to morning workflow
- [ ] Run `/adoflow daily summary` and verify disambiguation defaults to morning
- [ ] Verify API call counts match documented numbers in each command's diagnostic line

🤖 Generated with [Claude Code](https://claude.com/claude-code)